### PR TITLE
free_point의 KDTree 중복 계산 제거

### DIFF
--- a/dynamic_removal/map_remover.py
+++ b/dynamic_removal/map_remover.py
@@ -4,6 +4,8 @@ import numpy as np
 import open3d as o3d
 from tqdm import trange
 from scipy.spatial import KDTree
+import psutil, os
+import time
 
 from utils.session import Session
 from utils.session_map import SessionMap
@@ -56,6 +58,16 @@ class MapRemover:
         anchor_eph_l = np.ones(len(anchor_points.points)) * 0.5 # initial value
         anchor_kdtree = KDTree(np.asarray(anchor_points.points))
 
+        voxel_size = 0.1  # free_space_samples와 동일한 voxel 크기
+        threshold = self.std_dev_f * np.sqrt(np.log(self.alpha/self.beta))
+
+        noneffect_cache = {}  # 먼 free point → inds만 저장
+
+        def voxel_key(pt):
+            return (int(pt[0] / voxel_size),
+                    int(pt[1] / voxel_size),
+                    int(pt[2] / voxel_size))
+
         logger.info(f"Updating anchor local ephemerality")
         for i in trange(0, len(self.session_loader), p_dor["stride"], desc="Updating \u03B5_l", ncols=100):
 
@@ -83,15 +95,96 @@ class MapRemover:
             free_space_samples_o3d.points = o3d.utility.Vector3dVector(free_space_samples)
             free_space_samples_o3d = free_space_samples_o3d.voxel_down_sample(voxel_size=0.1)
             free_space_samples = np.asarray(free_space_samples_o3d.points)
-            dists, inds = anchor_kdtree.query(free_space_samples, k=p_dor["num_k"])
-            for j in range(len(dists)):
-                dist = dists[j]
-                eph_l_prev = anchor_eph_l[inds[j]]
-                update_rate = np.maximum(self.alpha * (1 + np.exp(-1 * dist**2 / self.std_dev_f)) - self.beta, self.alpha) # Eq. 5
-                eph_l_new = eph_l_prev * update_rate / (
-                    eph_l_prev * update_rate + (1 - eph_l_prev) * (1 - update_rate)
+            
+            # 파라미터
+            batch_size = 20000  # 1~5만 사이로 조정 가능
+
+            cache_miss = 0
+            cache_noneffect_hit = 0
+
+            # 1. 캐시 확인: hit이면 바로 업데이트, miss이면 모아서 batch query
+            pts_to_query = []
+            keys_to_query = []
+
+            for pt in free_space_samples:
+                key = voxel_key(pt)
+                if key in noneffect_cache:
+                    cache_noneffect_hit += 1
+                    inds = noneffect_cache[key]
+                    for ind in inds:
+                        eph_l_prev = anchor_eph_l[ind]
+                        update_rate = self.alpha
+                        eph_l_new = eph_l_prev * update_rate / (
+                            eph_l_prev * update_rate + (1 - eph_l_prev) * (1 - update_rate)
+                        )
+                        anchor_eph_l[ind] = eph_l_new
+                else:
+                    cache_miss += 1
+                    pts_to_query.append(pt)
+                    keys_to_query.append(key)
+
+            # 2. batch query (chunk 단위)
+            free_start_time = time.perf_counter()
+
+            if len(pts_to_query) > 0:
+                pts_to_query = np.array(pts_to_query)
+                num_pts = len(pts_to_query)
+
+                for start in range(0, num_pts, batch_size):
+                    end = min(start + batch_size, num_pts)
+                    pts_chunk = pts_to_query[start:end]
+                    keys_chunk = keys_to_query[start:end]
+
+                    # KDTree batch query
+                    dists_chunk, inds_chunk = anchor_kdtree.query(
+                        pts_chunk, k=p_dor["num_k"]
+                    )
+
+                    # query 결과 처리
+                    for key, dists, inds in zip(keys_chunk, dists_chunk, inds_chunk):
+                        dmin = np.min(dists)
+
+                        if dmin > threshold:
+                            # noneffect_cache에 등록
+                            noneffect_cache[key] = inds
+                            for ind in inds:
+                                eph_l_prev = anchor_eph_l[ind]
+                                update_rate = self.alpha
+                                eph_l_new = eph_l_prev * update_rate / (
+                                    eph_l_prev * update_rate + (1 - eph_l_prev) * (1 - update_rate)
+                                )
+                                anchor_eph_l[ind] = eph_l_new
+                        else:
+                            # 가까운 점 업데이트
+                            for dist, ind in zip(dists, inds):
+                                eph_l_prev = anchor_eph_l[ind]
+                                update_rate = np.maximum(
+                                    self.alpha * (1 + np.exp(-1 * dist**2 / self.std_dev_f)) - self.beta,
+                                    self.alpha,
+                                )
+                                eph_l_new = eph_l_prev * update_rate / (
+                                    eph_l_prev * update_rate + (1 - eph_l_prev) * (1 - update_rate)
+                                )
+                                anchor_eph_l[ind] = eph_l_new
+
+            free_end_time = time.perf_counter()
+
+            # 3. 로깅
+            total = cache_miss + cache_noneffect_hit
+            if total > 0:
+                logger.debug(
+                    f"noneffect_hit={cache_noneffect_hit/total:.1%}, "
+                    f"miss={cache_miss/total:.1%}"
                 )
-                anchor_eph_l[inds[j]] = eph_l_new
+                process = psutil.Process(os.getpid())
+                mem_mb = process.memory_info().rss / (1024**2)
+                logger.info(
+                    f"Cache size : noneffect={len(noneffect_cache)}  |  Memory usage: {mem_mb:.2f} MB"
+                )
+                logger.info(
+                    f"Free space update time: {free_end_time - free_start_time:.2f} s"
+                )
+                logger.info("")
 
         # 3) Propagate anchor local ephemerality to session map
         distances, indices = anchor_kdtree.query(np.asarray(session_map.points), k=p_dor["num_k"])


### PR DESCRIPTION
연속된 scan들은 비슷한 장소를 촬영하기 때문에, 동일한 (x, y, z) 위치는 여러 scan에서 중복되어 free point로 처리되는 경우가 많습니다. 정확히 같은 좌표가 아니더라도 voxel_down_sample을 사용할 경우 같은 voxel에 포함되면 동일한 점으로 취급되므로, 전체 free point의 30~45% 정도는 이전 scan에서 이미 처리된 점들임을 확인했습니다.

map_remover.py에서 핵심 연산은 2) occupied space update와 free space update인데, free space update는 occupied space update에 비해 처리해야 할 점의 수가 약 30배 많습니다. (0.5초 vs 25초) free space update 단계에서는 각 free point별로 anchor point와의 거리를 계산하기 위해 KDTree를 사용하고 있는데, 같은 위치의 free point가 여러 scan에 반복적으로 등장할 때마다 KDTree를 다시 실행하는 것은 비효율적입니다.

이에 대한 개선 아이디어는 다음과 같습니다.
scan 1에서 어떤 free point (x0, y0, z0)에 대해 KDTree를 통해 k개의 이웃 점과 거리 (dist1distk, ind1indk)를 얻었다면, scan 2에서 동일한 voxel에 해당하는 free point가 다시 등장했을 때는 KDTree를 다시 실행하지 않고, 이전에 계산된 결과를 캐시(dictionary)에서 가져와 사용하는 방식입니다. dictionary lookup은 O(1)이므로 KDTree 탐색(O(log N))보다 빠릅니다.

또한 anchor point와의 거리가 threshold 이상으로 멀면 update_rate가 α로 고정되므로, 이러한 free point는 dist 값에 관계없이 α로 처리됩니다. 이런 경우에는 dist는 저장할 필요가 없고 inds만 저장하면 되므로 메모리를 절약할 수 있습니다. threshold 값은 update_rate 식에서 α로 saturate되는 지점을 기준으로 합니다.

이 방식은 메모리 사용량 증가가 우려되므로, 모든 free point를 캐싱하는 대신 threshold 이상인 점들만 캐싱하도록 설계했습니다. voxel_size를 크게 하면 free point 수를 줄여 메모리와 연산 시간을 줄일 수 있지만, 해상도는 낮아지는 trade-off가 있습니다. 예시 측정 결과는 다음과 같습니다.

기존 방법: 28초
제안 방법: 22초
제안 방법 + voxel_size 0.2: 8초

추가적으로 scan은 순차적으로 이어지기 때문에, scan 500의 free point는 scan 1보다는 scan 499의 free point와 겹칠 확률이 높습니다. 따라서 메모리가 부족해질 경우 가장 오래된 scan에서 생성된 캐시 엔트리부터 삭제하는 방식도 고려 중입니다. 다만, 특정 시점 이전의 scan에서 생성된 엔트리만 효율적으로 제거하는 방법은 조금 더 고민이 필요합니다.


UROP 조한성 드림